### PR TITLE
Makefile: replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## What changed
- replaced `-p phpdbg` with `-p php` in both `coverage` target variants in `Makefile`
- kept the rest of the coverage command unchanged

## Why
- aligns this repository with the org-wide phpdbg removal tracked in contributte/contributte#73

## Testing
- verified the expanded command with `make -n coverage`